### PR TITLE
fixing test input to pass ctv1

### DIFF
--- a/Okta-Application/inputs/inputs_1_create.json
+++ b/Okta-Application/inputs/inputs_1_create.json
@@ -12,5 +12,5 @@
   },
   "Name": "bookmark",
   "Label": "test-label-1",
-  "SignOnMode": "SECURE_PASSWORD_STORE"
+  "SignOnMode": "BOOKMARK"
 }

--- a/Okta-Application/inputs/inputs_1_update.json
+++ b/Okta-Application/inputs/inputs_1_update.json
@@ -12,5 +12,5 @@
   },
   "Name": "bookmark",
   "Label": "test-label-1-updated",
-  "SignOnMode": "SECURE_PASSWORD_STORE"
+  "SignOnMode": "BOOKMARK"
 }

--- a/Okta-Application/okta-application-application.json
+++ b/Okta-Application/okta-application-application.json
@@ -294,8 +294,8 @@
   "writeOnlyProperties": [
     "/properties/Credentials",
     "/properties/RequestObjectSigningAlg",
-    "/properties/Settings/App/Url",
-    "/properties/Settings/App/AuthURL"
+    "/properties/Settings/App/AuthURL",
+    "/properties/Settings/App/SiteURL"
   ],
   "handlers": {
     "create": {


### PR DESCRIPTION
The ctv1 tests were failing which leads me to think the published resource in cloudformation is not the latest version of code with fixtures to Application resource.

Fixed ctv1 by updating:
SignOnMode sometimes switches values in response, this is done Okta side hence I changed the value to be `BOOKMARK` as this one comes back the same and makes the tests pass. 

WriteOnlyProps also updated as SiteURL is not returned in get response.